### PR TITLE
Adding Docker Image CI/CD Pipeline

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: fedcampus/dyn_flower_android_drf
       
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,40 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      


### PR DESCRIPTION
Title: **Adding Docker Image CI/CD Pipeline**

Description:

This pull request introduces a new GitHub Actions workflow that automatically builds and pushes Docker images to Docker Hub whenever there's a push or a pull request event on the main branch of the repository.

Here are the steps included in the workflow:

1. **Check out the repo**: This step uses the `actions/checkout` action to clone the repository's code onto the runner.
2. **Log in to Docker Hub**: This step uses the `docker/login-action` action to log into Docker Hub using the credentials stored in the repository's secrets.
3. **Extract metadata (tags, labels) for Docker**: This step uses the `docker/metadata-action` action to extract metadata about the Docker image.
4. **Build and push Docker image**: This step uses the `docker/build-push-action` action to build the Docker image using the Dockerfile in the backend directory, and then pushes the image to Docker Hub.

The workflow uses the `ubuntu-latest` GitHub-hosted runner and is triggered on `push` and `pull_request` events on the main branch.

Please review the code and provide feedback as needed. 