### PR TITLE
Enable model upload via REPL

### DIFF
--- a/backend/train/serializers.py
+++ b/backend/train/serializers.py
@@ -17,3 +17,10 @@ class TFLiteModelSerializer(serializers.Serializer):
 class PostServerDataSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     start_fresh = serializers.BooleanField(required=False, default=False)  # type: ignore
+
+
+# Always change together with `fed_kit.py`.
+class UploadDataSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=256)
+    layers_sizes = serializers.ListField(child=serializers.IntegerField(min_value=0))
+    data_type = serializers.CharField(max_length=256)

--- a/backend/train/serializers.py
+++ b/backend/train/serializers.py
@@ -19,7 +19,7 @@ class PostServerDataSerializer(serializers.Serializer):
     start_fresh = serializers.BooleanField(required=False, default=False)  # type: ignore
 
 
-# Always change together with `fed_kit.py`.
+# Always change together with `upload` in `fed_kit.py`.
 class UploadDataSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=256)
     layers_sizes = serializers.ListField(child=serializers.IntegerField(min_value=0))

--- a/backend/train/urls.py
+++ b/backend/train/urls.py
@@ -1,4 +1,8 @@
 from django.urls import path
 from train.views import *
 
-urlpatterns = [path("advertised", advertise_model), path("server", request_server)]
+urlpatterns = [
+    path("advertised", advertise_model),
+    path("server", request_server),
+    path("upload", upload_file),
+]

--- a/fed_kit.py
+++ b/fed_kit.py
@@ -1,11 +1,27 @@
-#!/usr/bin/env python3
-"""CLI App for FedKit backend operations."""
+"""FedKit backend operations package.
+
+Use this package from an interactive python shell:
+
+```python
+import fed_kit
+response = fed_kit.upload("test.tflite", "test_model", [100, 200, 300], "test_type")
+print(response)
+print(response.text)
+```
+"""
 import requests
 
 DEFAULT_URL = "http://localhost:8000/"
 
 
-def upload(base: str, file: str, name: str, layers_sizes: list[int], data_type: str):
+def upload(
+    file: str,
+    name: str,
+    layers_sizes: list[int],
+    data_type: str,
+    base: str = DEFAULT_URL,
+):
+    """Upload model `file` and store it as `name` on the backend."""
     url = base + "/train/upload"
     files = {"file": open(file, "rb")}
     data = {
@@ -14,15 +30,3 @@ def upload(base: str, file: str, name: str, layers_sizes: list[int], data_type: 
         "data_type": data_type,
     }
     return requests.post(url, data=data, files=files)
-
-
-def main():
-    response = upload(
-        DEFAULT_URL, "test.txt", "test_model", [100, 200, 300], "test_type"
-    )
-    print(response)
-    print(response.text)
-
-
-if __name__ == "__main__":
-    main()

--- a/fed_kit.py
+++ b/fed_kit.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""CLI App for FedKit backend operations."""
+import requests
+
+
+def main():
+    url = "http://localhost:8000/train/upload"  # Replace with your Django server URL
+    files = {"file": open("test.txt", "rb")}
+    response = requests.post(url, files=files)
+    print(response)
+    print(response.reason)
+
+
+if __name__ == "__main__":
+    main()

--- a/fed_kit.py
+++ b/fed_kit.py
@@ -2,16 +2,24 @@
 """CLI App for FedKit backend operations."""
 import requests
 
+DEFAULT_URL = "http://localhost:8000/"
+
+
+def upload(base: str, file: str, name: str, layers_sizes: list[int], data_type: str):
+    url = base + "/train/upload"
+    files = {"file": open(file, "rb")}
+    data = {
+        "name": name,
+        "layers_sizes": layers_sizes,
+        "data_type": data_type,
+    }
+    return requests.post(url, data=data, files=files)
+
 
 def main():
-    url = "http://localhost:8000/train/upload"  # Replace with your Django server URL
-    files = {"file": open("test.txt", "rb")}
-    data = {
-        "name": "test_model",
-        "layers_sizes": [100, 200, 300],
-        "data_type": "test_type",
-    }
-    response = requests.post(url, data=data, files=files)
+    response = upload(
+        DEFAULT_URL, "test.txt", "test_model", [100, 200, 300], "test_type"
+    )
     print(response)
     print(response.text)
 

--- a/fed_kit.py
+++ b/fed_kit.py
@@ -6,9 +6,14 @@ import requests
 def main():
     url = "http://localhost:8000/train/upload"  # Replace with your Django server URL
     files = {"file": open("test.txt", "rb")}
-    response = requests.post(url, files=files)
+    data = {
+        "name": "test_model",
+        "layers_sizes": [100, 200, 300],
+        "data_type": "test_type",
+    }
+    response = requests.post(url, data=data, files=files)
     print(response)
-    print(response.reason)
+    print(response.text)
 
 
 if __name__ == "__main__":

--- a/fed_kit.py
+++ b/fed_kit.py
@@ -14,6 +14,7 @@ import requests
 DEFAULT_URL = "http://localhost:8000/"
 
 
+# Always change together with `UploadDataSerializer` in `train.serializers`.
 def upload(
     file: str,
     name: str,


### PR DESCRIPTION
Backend now takes model file and parameters from `/train/upload`.

We also provide `fed_kit.py` to enable uploading using the REPL instead of hand-writing the POST request:

```python
$ ipython
In [1]: import fed_kit
response = fed_kit.upload("test.tflite", "test_model", [100, 200, 300], "test_type")
```
